### PR TITLE
Feat: 블럭의 종류에 따라 다른 색상을 그리는 기능

### DIFF
--- a/src/team11/tetris/blocks/Block.java
+++ b/src/team11/tetris/blocks/Block.java
@@ -1,21 +1,23 @@
 package team11.tetris.blocks;
 
+import team11.tetris.utills.BoardElement;
+
 import java.awt.Color;
 
 public abstract class Block {
 		
-	protected int[][] shape;
+	protected BoardElement[][] shape;
 	protected Color color;
 	
 	public Block() {
-		shape = new int[][]{ 
-				{1, 1}, 
-				{1, 1}
+		shape = new BoardElement[][]{
+				{BoardElement.O_BLOCK, BoardElement.O_BLOCK},
+				{BoardElement.O_BLOCK, BoardElement.O_BLOCK}
 		};
 		color = Color.YELLOW;
 	}
 	
-	public int getShape(int x, int y) {
+	public BoardElement getShape(int x, int y) {
 		return shape[y][x];
 	}
 	

--- a/src/team11/tetris/blocks/IBlock.java
+++ b/src/team11/tetris/blocks/IBlock.java
@@ -1,13 +1,15 @@
 package team11.tetris.blocks;
 
+import team11.tetris.utills.BoardElement;
+
 import java.awt.Color;
 
 public class IBlock extends Block {
 	
 	public IBlock() {
-		shape = new int[][] { 
-			{1, 1, 1, 1}
+		shape = new BoardElement[][] {
+			{BoardElement.I_BLOCK, BoardElement.I_BLOCK, BoardElement.I_BLOCK, BoardElement.I_BLOCK}
 		};
-		color = Color.CYAN;
+		color = BoardElement.getElementColor(BoardElement.I_BLOCK);
 	}
 }

--- a/src/team11/tetris/blocks/JBlock.java
+++ b/src/team11/tetris/blocks/JBlock.java
@@ -1,14 +1,16 @@
 package team11.tetris.blocks;
 
+import team11.tetris.utills.BoardElement;
+
 import java.awt.Color;
 
 public class JBlock extends Block {
 	
 	public JBlock() {
-		shape = new int[][] { 
-				{1, 1, 1},
-				{0, 0, 1}
+		shape = new BoardElement[][] {
+				{BoardElement.J_BLOCK, BoardElement.J_BLOCK, BoardElement.J_BLOCK},
+				{BoardElement.EMPTY, BoardElement.EMPTY, BoardElement.J_BLOCK}
 		};
-		color = Color.BLUE;
+		color = BoardElement.getElementColor(BoardElement.J_BLOCK);
 	}
 }

--- a/src/team11/tetris/blocks/LBlock.java
+++ b/src/team11/tetris/blocks/LBlock.java
@@ -1,14 +1,16 @@
 package team11.tetris.blocks;
 
+import team11.tetris.utills.BoardElement;
+
 import java.awt.Color;
 
 public class LBlock extends Block {
 	
 	public LBlock() {
-		shape = new int[][] { 
-			{1, 1, 1},
-			{1, 0, 0}
+		shape = new BoardElement[][] {
+			{BoardElement.L_BLOCK, BoardElement.L_BLOCK, BoardElement.L_BLOCK},
+			{BoardElement.L_BLOCK, BoardElement.EMPTY, BoardElement.EMPTY}
 		};
-		color = Color.ORANGE;
+		color = BoardElement.getElementColor(BoardElement.L_BLOCK);
 	}
 }

--- a/src/team11/tetris/blocks/OBlock.java
+++ b/src/team11/tetris/blocks/OBlock.java
@@ -1,14 +1,16 @@
 package team11.tetris.blocks;
 
+import team11.tetris.utills.BoardElement;
+
 import java.awt.Color;
 
 public class OBlock extends Block {
 
 	public OBlock() {
-		shape = new int[][] { 
-			{1, 1}, 
-			{1, 1}
+		shape = new BoardElement[][] {
+			{BoardElement.O_BLOCK, BoardElement.O_BLOCK},
+			{BoardElement.O_BLOCK, BoardElement.O_BLOCK}
 		};
-		color = Color.YELLOW;
+		color = BoardElement.getElementColor(BoardElement.O_BLOCK);
 	}
 }

--- a/src/team11/tetris/blocks/SBlock.java
+++ b/src/team11/tetris/blocks/SBlock.java
@@ -1,14 +1,16 @@
 package team11.tetris.blocks;
 
+import team11.tetris.utills.BoardElement;
+
 import java.awt.Color;
 
 public class SBlock extends Block {
 
 	public SBlock() {
-		shape = new int[][] { 
-			{0, 1, 1},
-			{1, 1, 0}
+		shape = new BoardElement[][] {
+			{BoardElement.EMPTY, BoardElement.S_BLOCK, BoardElement.S_BLOCK},
+			{BoardElement.S_BLOCK, BoardElement.S_BLOCK, BoardElement.EMPTY}
 		};
-		color = Color.GREEN;
+		color = BoardElement.getElementColor(BoardElement.S_BLOCK);
 	}
 }

--- a/src/team11/tetris/blocks/TBlock.java
+++ b/src/team11/tetris/blocks/TBlock.java
@@ -1,14 +1,16 @@
 package team11.tetris.blocks;
 
+import team11.tetris.utills.BoardElement;
+
 import java.awt.Color;
 
 public class TBlock extends Block {
 	
 	public TBlock() {
-		shape = new int[][] { 
-			{0, 1, 0},
-			{1, 1, 1}
+		shape = new BoardElement[][] {
+			{BoardElement.EMPTY, BoardElement.T_BLOCK, BoardElement.EMPTY},
+			{BoardElement.T_BLOCK, BoardElement.T_BLOCK, BoardElement.T_BLOCK}
 		};
-		color = Color.MAGENTA;
+		color = BoardElement.getElementColor(BoardElement.T_BLOCK);
 	}
 }

--- a/src/team11/tetris/blocks/ZBlock.java
+++ b/src/team11/tetris/blocks/ZBlock.java
@@ -1,14 +1,16 @@
 package team11.tetris.blocks;
 
+import team11.tetris.utills.BoardElement;
+
 import java.awt.Color;
 
 public class ZBlock extends Block {
 	
 	public ZBlock() {
-		shape = new int[][] { 
-			{1, 1, 0},
-			{0, 1, 1}
+		shape = new BoardElement[][] {
+			{BoardElement.Z_BLOCK, BoardElement.Z_BLOCK, BoardElement.EMPTY},
+			{BoardElement.EMPTY, BoardElement.Z_BLOCK, BoardElement.Z_BLOCK}
 		};
-		color = Color.RED;
+		color = BoardElement.getElementColor(BoardElement.Z_BLOCK);
 	}
 }

--- a/src/team11/tetris/model/BoardModel.java
+++ b/src/team11/tetris/model/BoardModel.java
@@ -1,13 +1,14 @@
 package team11.tetris.model;
 
 import team11.tetris.blocks.*;
+import team11.tetris.utills.BoardElement;
 
 import java.util.ArrayList;
 import java.util.Random;
 import java.awt.Color;
 
 public class BoardModel {
-    public ArrayList<Integer[]> board;
+    public ArrayList<BoardElement[]> board;
     public Block currentBlock;
     public Block nextBlock;
     public int x = 3; // Default Position.
@@ -21,7 +22,7 @@ public class BoardModel {
         initBoard(configModel.WIDTH, configModel.HEIGHT);
     }
 
-    public ArrayList<Integer[]> getBoard() {
+    public ArrayList<BoardElement[]> getBoard() {
         return board;
     }
 
@@ -32,17 +33,17 @@ public class BoardModel {
     public void eraseCurr() {
         for (int i = x; i < x + currentBlock.width(); i++) {
             for (int j = y; j < y + currentBlock.height(); j++) {
-                board.get(j)[i] = 0;
+                board.get(j)[i] = BoardElement.EMPTY;
             }
         }
     }
 
     public void initBoard(int width, int height) {
-        this.board = new ArrayList<Integer[]>(height);
+        this.board = new ArrayList<BoardElement[]>(height);
         for (int i = 0; i < height; i++) {
-            Integer[] row = new Integer[width];
+            BoardElement[] row = new BoardElement[width];
             for (int j = 0; j < width; j++)
-                row[j] = 0;
+                row[j] = BoardElement.EMPTY;
             board.add(row);
         }
     }
@@ -50,7 +51,6 @@ public class BoardModel {
     public void setRandomBlock() {
         Random rnd = new Random(System.currentTimeMillis());
         int block = rnd.nextInt(6);
-        System.out.println(block);
         switch (block) {
             case 0:
                 currentBlock = new IBlock();

--- a/src/team11/tetris/model/ConfigModel.java
+++ b/src/team11/tetris/model/ConfigModel.java
@@ -3,5 +3,4 @@ package team11.tetris.model;
 public class ConfigModel {
     public static final int HEIGHT = 20;
     public static final int WIDTH = 10;
-    public static final char BORDER_CHAR = 'X';
 }

--- a/src/team11/tetris/presenter/BoardPresenter.java
+++ b/src/team11/tetris/presenter/BoardPresenter.java
@@ -21,7 +21,7 @@ public class BoardPresenter {
         this.boardView = new BoardView(this);
 
         this.boardModel.setRandomBlock();
-        this.boardView.drawBoard(this.boardModel.getBoard(), this.boardModel.getColor());
+        this.boardView.drawBoard(this.boardModel.getBoard());
 
         timer = new Timer(initInterval, new TimerActionListener());
         timer.start();
@@ -33,7 +33,7 @@ public class BoardPresenter {
             if (!boardModel.moveDown()) {
                 boardModel.setRandomBlock();
             }
-            boardView.drawBoard(boardModel.getBoard(), boardModel.getColor());
+            boardView.drawBoard(boardModel.getBoard());
         }
     }
 
@@ -48,17 +48,17 @@ public class BoardPresenter {
 
     public void moveDown() {
         boardModel.moveDown();
-        boardView.drawBoard(boardModel.getBoard(), boardModel.getColor());
+        boardView.drawBoard(boardModel.getBoard());
     }
 
     public void moveLeft() {
         boardModel.moveLeft();
-        boardView.drawBoard(boardModel.getBoard(), boardModel.getColor());
+        boardView.drawBoard(boardModel.getBoard());
     }
 
     public void moveRight() {
         boardModel.moveRight();
-        boardView.drawBoard(boardModel.getBoard(), boardModel.getColor());
+        boardView.drawBoard(boardModel.getBoard());
     }
 
 

--- a/src/team11/tetris/utills/BoardElement.java
+++ b/src/team11/tetris/utills/BoardElement.java
@@ -1,0 +1,30 @@
+package team11.tetris.utills;
+
+import java.awt.*;
+
+public enum BoardElement {
+    EMPTY, BORDER, I_BLOCK, J_BLOCK, L_BLOCK, O_BLOCK, S_BLOCK, T_BLOCK, Z_BLOCK;
+    // @TODO 추후 아이템 Enum값 추가
+
+    public static Color getElementColor(BoardElement element) {
+        return switch (element) {
+            case EMPTY -> Color.BLACK;
+            case BORDER -> Color.WHITE;
+            case I_BLOCK -> Color.CYAN;
+            case J_BLOCK -> Color.BLUE;
+            case L_BLOCK -> Color.ORANGE;
+            case O_BLOCK -> Color.YELLOW;
+            case S_BLOCK -> Color.GREEN;
+            case T_BLOCK -> Color.MAGENTA;
+            case Z_BLOCK -> Color.RED;
+        };
+    }
+
+    public static String getElementText(BoardElement element) {
+        return switch (element) {
+            case EMPTY -> " ";
+            case BORDER -> "X";
+            case I_BLOCK, J_BLOCK, L_BLOCK, O_BLOCK, S_BLOCK, T_BLOCK, Z_BLOCK -> "O";
+        };
+    }
+}

--- a/src/team11/tetris/view/BoardView.java
+++ b/src/team11/tetris/view/BoardView.java
@@ -88,7 +88,7 @@ public class BoardView extends JFrame {
 		}
 	}
 
-	public void drawBoard(ArrayList<BoardElement[]> board, Color color) {
+	public void drawBoard(ArrayList<BoardElement[]> board) {
 		// Set Config
 		pane.setText("");
 		Style style = pane.addStyle("textStyle", null);

--- a/src/team11/tetris/view/BoardView.java
+++ b/src/team11/tetris/view/BoardView.java
@@ -1,23 +1,17 @@
 package team11.tetris.view;
 
-import team11.tetris.blocks.Block;
-import team11.tetris.model.BoardModel;
-import team11.tetris.model.ConfigModel;
 import team11.tetris.presenter.BoardPresenter;
+import team11.tetris.utills.BoardElement;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Font;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyListener;
 import java.awt.event.KeyEvent;
-import java.io.File;
 import java.util.ArrayList;
 
 import javax.swing.BorderFactory;
 import javax.swing.JFrame;
 import javax.swing.JTextPane;
-import javax.swing.Timer;
 import javax.swing.border.CompoundBorder;
 import javax.swing.text.*;
 
@@ -94,31 +88,28 @@ public class BoardView extends JFrame {
 		}
 	}
 
-	public void drawBoard(ArrayList<Integer[]> board, Color color) {
+	public void drawBoard(ArrayList<BoardElement[]> board, Color color) {
+		// Set Config
 		pane.setText("");
 		Style style = pane.addStyle("textStyle", null);
-		StyleConstants.setForeground(style, Color.white);
 		StyledDocument doc = pane.getStyledDocument();
 
+		// Build Styled Document
 		try {
-			for (int t = 0; t < board.get(0).length + 2; t++)
-				doc.insertString(doc.getLength(), Character.toString('X'), style);
-			doc.insertString(doc.getLength(), "\n", style);
-
-			for (int i = 0; i < board.size(); i++) {
-				doc.insertString(doc.getLength(), Character.toString('X'), style);
-				for (int j = 0; j < board.get(i).length; j++) {
-					StyleConstants.setForeground(style, color);
-					doc.insertString(doc.getLength(), board.get(i)[j] > 0 ? "0" : " ", style);
+			for(int i=0; i<board.size() + 2; i++) {
+				for(int j=0; j<board.get(0).length + 2; j++) {
+					boolean isBorder = i == 0 || i == board.size() + 1 || j == 0 || j == board.get(0).length + 1;
+					if(isBorder) {
+						StyleConstants.setForeground(style, BoardElement.getElementColor(BoardElement.BORDER));
+						doc.insertString(doc.getLength(), BoardElement.getElementText(BoardElement.BORDER), style);
+					} else {
+						StyleConstants.setForeground(style, BoardElement.getElementColor(board.get(i-1)[j-1]));
+						doc.insertString(doc.getLength(), BoardElement.getElementText(board.get(i-1)[j-1]), style);
+					}
 				}
-				StyleConstants.setForeground(style, Color.white);
-				doc.insertString(doc.getLength(), Character.toString('X') + "\n", style);
+				doc.insertString(doc.getLength(), "\n", style);
 			}
-
-			for (int t = 0; t < board.get(0).length + 2; t++)
-				doc.insertString(doc.getLength(), Character.toString('X'), style);
-		} catch (BadLocationException e) {
-		}
+		} catch (BadLocationException e) {}
 
 		doc.setParagraphAttributes(0, doc.getLength(), styleSet, false);
 		pane.setStyledDocument(doc);


### PR DESCRIPTION
## 개발사항

### 이전 상황

블럭의 값이 1로 통일되어 블럭의 종류를 구분할 수 없어 색상을 다르게 표시할 수 없었음

#4 #5

### 개발 후 상황

Public Enum을 작성하여 보드에 표시되는 요소에 대한 값을 정의해줬고 이에 따라 색상과 텍스트도 얻을 수 있도록 했습니다.

## 추가사항

ConfigModel에서 BorderChar 상수를 제거하고 Enum에서 정의해줬습니다.